### PR TITLE
Allow viewing IR camera + Update exposure slider accordingly in auto exposure

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -128,5 +128,7 @@ sample_record_rrf\.py
 sample_retrieve_data\.py
 include
 
+!/roypycy_defs.cpp
+
 # macOS
 .DS_Store

--- a/README.md
+++ b/README.md
@@ -27,15 +27,15 @@ If the requirements where not installed correctly, you should see the following 
 world - [WARNING] plugin: Failed to load 'picoflexx'. Reason: '<reason>'
 ```
 
-### Compile backend extension to greatly improve performance (optional)
+### Compile roypycy extension
 1. Copy (or symlink) the Royale SDK `include` folder here, e.g. `ln -s /path/to/libroyale-3.20.0.62-LINUX-x86-64Bit/include .`
 1. `python setup.py build_ext`
 
 If the extension was not compiled/setup correctly, you should see the following line:
 ```log
-world - [WARNING] picoflexx.backend: Failed to load roypy_backend extension, falling back to roypy
+world - [WARNING] picoflexx.backend: Pico Flexx backend requirements (roypycy) not installed properly
 ```
-If you're getting `ImportError: cannot import name 'roypy_backend'` even though the library was compiled, a common cause is the python version used to compile the extension differs from that used by Pupil Capture (Python 3.6).
+If you're getting `ImportError: cannot import name 'roypycy'` even though the library was compiled, a common cause is the python version used to compile the extension differs from that used by Pupil Capture (Python 3.6).
 
 ## Usage
 

--- a/backend.py
+++ b/backend.py
@@ -243,6 +243,9 @@ class Picoflexx_Source(Playback_Source, Base_Source):
         self.camera.startCapture()
 
     def set_exposure_delayed(self, exposure):
+        # set displayed exposure early, to reduce jankiness while dragging slider
+        self._current_exposure = exposure
+
         self.notify_all(
             {"subject": "picoflexx.set_exposure", "delay": 0.3, "exposure": exposure}
         )
@@ -255,8 +258,6 @@ class Picoflexx_Source(Playback_Source, Base_Source):
                     status, roypy.getStatusString(status)
                 )
             )
-
-        self._current_exposure = exposure
 
     def get_exposure_mode(self):
         return roypycy.get_exposure_mode(self.camera) == 1

--- a/backend.py
+++ b/backend.py
@@ -199,6 +199,9 @@ class Picoflexx_Source(Playback_Source, Base_Source):
             )
             self._ui_exposure = self.menu[-1]
 
+            self._current_exposure_mode = self.get_exposure_mode()
+            self._ui_exposure.read_only = self._current_exposure_mode
+
             self.menu.append(
                 ui.Switch(
                     "selected_exposure_mode",
@@ -262,6 +265,7 @@ class Picoflexx_Source(Playback_Source, Base_Source):
     def set_exposure_mode(self, exposure_mode):
         roypycy.set_exposure_mode(self.camera, 1 if exposure_mode else 0)
         self._current_exposure_mode = exposure_mode
+        self._ui_exposure.read_only = exposure_mode
 
     def recent_events(self, events):
         frame = self.get_frame()

--- a/backend.py
+++ b/backend.py
@@ -54,6 +54,7 @@ class Frame(object):
         # self.timestamp = depth_data.timeStamp  # Not memory safe!
         self.timestamp = None
         self._data = roypycy.get_backend_data(depth_data)
+        self.exposure_times = depth_data.exposureTimes
 
         self.height = depth_data.height
         self.width = depth_data.width
@@ -272,6 +273,9 @@ class Picoflexx_Source(Playback_Source, Base_Source):
         if frame:
             events["frame"] = frame
             self._recent_frame = frame
+
+            if self._current_exposure_mode:  # auto exposure
+                self._current_exposure = frame.exposure_times[1]
 
     def get_frame(self):
         try:

--- a/backend.py
+++ b/backend.py
@@ -134,9 +134,7 @@ class Picoflexx_Source(Playback_Source, Base_Source):
         self.frame_count = 0
 
         self._ui_exposure = None
-        self._current_exposure = (
-            0
-        )  # TODO obtain current exposure from most recent DepthData event
+        self._current_exposure = 0
         self._current_exposure_mode = False
 
     def init_device(self):

--- a/example_plugin.py
+++ b/example_plugin.py
@@ -14,20 +14,28 @@ from plugin import Plugin
 
 class Example_Picoflexx_Plugin(Plugin):
     def recent_events(self, events):
-        if "frame" in events and hasattr(events["frame"], "dense_pointcloud"):
+        if "frame" in events:
             pass
+            # IR image
             # frame = events["frame"]
+            # frame.gray
+
+        if "depth_frame" in events and hasattr(
+            events["depth_frame"], "dense_pointcloud"
+        ):
+            pass
+            # depth_frame = events["depth_frame"]
 
             # access point cloud, dimensions: (height*width) x 3, dtype: float [meter]
-            # frame.dense_pointcloud
+            # depth_frame.dense_pointcloud
 
             # access depth values only, dimensions: height x width, dtype: float [meter]
-            # frame.dense_pointcloud[:, 3].reshape(frame.height, frame.width)
+            # depth_frame.dense_pointcloud[:, 3].reshape(depth_frame.height, depth_frame.width)
 
             # cloud point confidence and noise, dimensions: height x width
-            # frame.noise  # dtype: float [meter]
-            # frame.depthConfidence  # dtype: uint8 [0: invalid, 255: full confidence]
+            # depth_frame.noise  # dtype: float [meter]
+            # depth_frame.depthConfidence  # dtype: uint8 [0: invalid, 255: full confidence]
 
             # 2d visualization using cumulative histogram mapping
             # dimensions: height x width x 3, dtype: uint8
-            # frame.img
+            # depth_frame.img

--- a/roypycy_defs.cpp
+++ b/roypycy_defs.cpp
@@ -1,0 +1,16 @@
+#include <Python.h>
+#include "royale/IIRImageListener.hpp"
+
+class PyIRImageListener: public royale::IIRImageListener {
+    public:
+    PyIRImageListener (void* obj, PyObject* (*callback)(void*, royale::IRImage *data)) {
+        this->obj = obj;
+        this->callback = callback;
+    };
+    void onNewData (const royale::IRImage *data) {
+        (*this->callback)(this->obj, (royale::IRImage *) data);
+    };
+
+    void *obj;
+    PyObject* (*callback)(void*, royale::IRImage *data);
+};

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ from distutils.core import setup
 extensions = [
     Extension(
         "roypycy",
-        ["roypycy.pyx"],
+        ["roypycy.pyx", "roypycy_defs.cpp"],
         library_dirs=["."],
         libraries=["royale"],
         include_dirs=["include"],


### PR DESCRIPTION
~~The current method to update the exposure slider with auto exposure enabled doesn't work when displaying the IR camera. As the current exposure is obtained from the depth data rather than using an `ExposureListener`.~~