### PR TITLE
Check timestamps of IR and Depth data

### DIFF
--- a/backend.py
+++ b/backend.py
@@ -144,6 +144,8 @@ class DepthDataListener(roypy.IDepthDataListener):
     def _check_frame(self):
         if self._data_depth is None or self._data_ir is None:
             return
+        if roypycy.get_depth_data_ts(self._data_depth) != self._data_ir.timestamp:
+            return
 
         try:
             frame_depth = DepthFrame(self._data_depth)

--- a/backend.py
+++ b/backend.py
@@ -83,8 +83,7 @@ class IRFrame(object):
 
 class DepthFrame(object):
     def __init__(self, depth_data):
-        # self.timestamp = depth_data.timeStamp  # Not memory safe!
-        self.timestamp = None
+        self.timestamp = roypycy.get_depth_data_ts(depth_data)  # microseconds
         self._data = roypycy.get_backend_data(depth_data)
         self.exposure_times = depth_data.exposureTimes
 

--- a/roypycy.pyx
+++ b/roypycy.pyx
@@ -10,6 +10,10 @@ cdef extern from "swigpyobject.h":
     ctypedef struct SwigPyObject:
         void *ptr
 
+cdef extern from "<chrono>" namespace "std::chrono":
+    cdef cppclass microseconds:
+        long int count()  # FIXME: the type is technically an implementation detail
+
 cdef extern from "royale/Vector.hpp" namespace "royale":
     cdef cppclass Vector[T]:
         cppclass iterator:
@@ -71,7 +75,7 @@ cdef extern from "royale/LensParameters.hpp" namespace "royale":
 cdef extern from "royale/DepthData.hpp" namespace "royale":
     ctypedef struct DepthData:
         int                         version;         # !< version number of the data format
-        # std::chrono::microseconds   timeStamp;       # !< timestamp in microseconds precision (time since epoch 1970)
+        microseconds                timeStamp;       # !< timestamp in microseconds precision (time since epoch 1970)
         # StreamId                    streamId;        # !< stream which produced the data
         uint16_t                    width;           # !< width of depth image
         uint16_t                    height;          # !< height of depth image
@@ -98,6 +102,14 @@ cdef extern from "royale/ICameraDevice.hpp" namespace "royale":
         int getLensParameters(LensParameters &params)
         int registerIRImageListener(IIRImageListener *listener)
         int unregisterIRImageListener()
+
+
+def get_depth_data_ts(depthdata):
+    cdef SwigPyObject *swig_obj = <SwigPyObject*>depthdata.this
+    cdef DepthData *mycpp_ptr = <DepthData*?>swig_obj.ptr
+    cdef DepthData my_instance = mycpp_ptr[0]
+
+    return my_instance.timeStamp.count()
 
 
 def get_depth_data(depthdata):


### PR DESCRIPTION
Partially completes #3 

In my testing, timestamps were perfectly matched between successive pairs of IR and depth data.