### PR TITLE
Misc changes

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -10,8 +10,8 @@ See COPYING and COPYING.LESSER for license details.
 """
 
 try:
-    from picoflexx.backend import Picoflexx_Source, Picoflexx_Manager
-    from picoflexx.example_plugin import Example_Picoflexx_Plugin
+    from .backend import Picoflexx_Source, Picoflexx_Manager
+    from .example_plugin import Example_Picoflexx_Plugin
 except (ImportError, AssertionError):
     import traceback
     traceback.print_exc()

--- a/backend.py
+++ b/backend.py
@@ -258,8 +258,8 @@ class Picoflexx_Source(Playback_Source, Base_Source):
         self.frame_count = 0
         self.record_pointcloud = record_pointcloud
 
-        self._recent_frame = None
-        self._recent_depth_frame = None
+        self._recent_frame = None  # type: Optional[IRFrame]
+        self._recent_depth_frame = None  # type: Optional[DepthFrame]
 
         self._ui_exposure = None
         self._current_exposure = current_exposure

--- a/backend.py
+++ b/backend.py
@@ -425,26 +425,13 @@ class Picoflexx_Source(Playback_Source, Base_Source):
             return
 
         video_path = os.path.join(rec_loc, "pointcloud.rrf")
-        status = self.camera.startRecording(video_path, 0, 0, 0)
-
-        if status != 0:
-            logger.warning(
-                "setExposureTime: Non-zero return: {} - {}".format(
-                    status, roypy.getStatusString(status)
-                )
-            )
+        roypy_wrap(self.camera.startRecording, (video_path, 0, 0, 0))
 
     def stop_pointcloud_recording(self):
         if not self.record_pointcloud:
             return
 
-        status = self.camera.stopRecording()
-        if status != 0:
-            logger.warning(
-                "setExposureTime: Non-zero return: {} - {}".format(
-                    status, roypy.getStatusString(status)
-                )
-            )
+        roypy_wrap(self.camera.stopRecording)
 
     def set_usecase(self, usecase):
         roypy_wrap(self.camera.setUseCase, usecase)

--- a/backend.py
+++ b/backend.py
@@ -420,7 +420,7 @@ class Picoflexx_Source(Playback_Source, Base_Source):
             return
 
         video_path = os.path.join(rec_loc, "pointcloud.rrf")
-        roypy_wrap(self.camera.startRecording, (video_path, 0, 0, 0))
+        roypy_wrap(self.camera.startRecording, video_path, 0, 0, 0)
 
     def stop_pointcloud_recording(self):
         if not self.record_pointcloud:

--- a/backend.py
+++ b/backend.py
@@ -241,15 +241,10 @@ class Picoflexx_Source(Playback_Source, Base_Source):
         record_pointcloud=False,
         current_exposure=0,
         selected_usecase=None,
-        color_z_min=0.4,
-        color_z_max=1.0,
         *args,
         **kwargs,
     ):
         super().__init__(g_pool, *args, **kwargs)
-        self.color_z_min = color_z_min
-        self.color_z_max = color_z_max
-
         self.camera = None
         self.queue = queue.Queue(maxsize=1)
         self.data_listener = DepthDataListener(self.queue)

--- a/backend.py
+++ b/backend.py
@@ -253,7 +253,6 @@ class Picoflexx_Source(Playback_Source, Base_Source):
         self.queue = queue.Queue(maxsize=1)
         self.data_listener = DepthDataListener(self.queue)
 
-        self.fps = 30
         self.frame_count = 0
         self.record_pointcloud = record_pointcloud
 
@@ -501,7 +500,7 @@ class Picoflexx_Source(Playback_Source, Base_Source):
 
     @property
     def frame_rates(self):
-        return (30, 30)
+        return 1, self.camera.getMaxFrameRate() if self.online else 30
 
     @property
     def frame_sizes(self):
@@ -509,7 +508,7 @@ class Picoflexx_Source(Playback_Source, Base_Source):
 
     @property
     def frame_rate(self):
-        return self.fps
+        return self.camera.getFrameRate() if self.online else 30
 
     @frame_rate.setter
     def frame_rate(self, new_rate):
@@ -518,10 +517,10 @@ class Picoflexx_Source(Playback_Source, Base_Source):
         rate = self.frame_rates[best_rate_idx]
         if rate != new_rate:
             logger.warning(
-                "%sfps capture mode not available at (%s) on 'Fake Source'. Selected %sfps. "
+                "%sfps capture mode not available at (%s) on 'PicoFlexx Source'. Selected %sfps. "
                 % (new_rate, self.frame_size, rate)
             )
-        self.fps = rate
+        roypy_wrap(self.camera.setFrameRate, rate)
 
     @property
     def jpeg_support(self):

--- a/backend.py
+++ b/backend.py
@@ -423,6 +423,9 @@ class Picoflexx_Source(Playback_Source, Base_Source):
             )
 
     def stop_pointcloud_recording(self):
+        if not self.record_pointcloud:
+            return
+
         status = self.camera.stopRecording()
         if status != 0:
             logger.warning(

--- a/backend.py
+++ b/backend.py
@@ -253,6 +253,7 @@ class Picoflexx_Source(Playback_Source, Base_Source):
         self.queue = queue.Queue(maxsize=1)
         self.data_listener = DepthDataListener(self.queue)
 
+        self.selected_usecase = None
         self.frame_count = 0
         self.record_pointcloud = record_pointcloud
 
@@ -314,14 +315,12 @@ class Picoflexx_Source(Playback_Source, Base_Source):
                 for uc in range(use_cases.size())
                 if "MIXED" not in use_cases[uc]
             ]
-            default = "Select to activate"
-            use_cases.insert(0, default)
 
             self.menu.append(
                 ui.Selector(
                     "selected_usecase",
                     selection=use_cases,
-                    getter=lambda: default,
+                    getter=lambda: self.selected_usecase,
                     setter=self.set_usecase,
                     label="Activate usecase",
                 )
@@ -368,6 +367,7 @@ class Picoflexx_Source(Playback_Source, Base_Source):
             logger.error("Can't get state, not online")
             return
 
+        self.selected_usecase = self.camera.getCurrentUseCase()
         self._current_exposure_mode = self.get_exposure_mode()
         exposure_limits = self.camera.getExposureLimits()
         if self._current_exposure > exposure_limits.second:

--- a/backend.py
+++ b/backend.py
@@ -429,12 +429,11 @@ class Picoflexx_Source(Playback_Source, Base_Source):
             )
 
     def set_usecase(self, usecase):
-        if self.camera.isCapturing():
-            roypy_wrap(self.camera.stopCapture)
         roypy_wrap(self.camera.setUseCase, usecase)
 
+        if not self.camera.isCapturing():
+            roypy_wrap(self.camera.startCapture)
 
-        roypy_wrap(self.camera.startCapture)
         self.load_camera_state()
 
     def set_exposure_delayed(self, exposure):

--- a/backend.py
+++ b/backend.py
@@ -571,7 +571,7 @@ class Picoflexx_Source(Playback_Source, Base_Source):
             if self._preview_depth and self._recent_depth_frame is not None:
                 self.g_pool.image_tex.update_from_ndarray(self._recent_depth_frame.bgr)
             elif self._recent_frame is not None:
-                self.g_pool.image_tex.update_from_ndarray(self._recent_frame.gray)
+                self.g_pool.image_tex.update_from_ndarray(self._recent_frame.img)
             gl_utils.glFlush()
             gl_utils.make_coord_system_norm_based()
             self.g_pool.image_tex.draw()

--- a/backend.py
+++ b/backend.py
@@ -10,21 +10,20 @@ See COPYING and COPYING.LESSER for license details.
 """
 
 import collections
-import itertools
-import logging
-import queue
-import os
-from time import sleep, time
+from time import time
 
+import cv2
+import logging
 import numpy as np
+import os
+import queue
 from pyglui import ui
 from typing import Tuple, Optional
 
-import cv2
 import cython_methods
 import gl_utils
-from camera_models import load_intrinsics, Radial_Dist_Camera, Dummy_Camera
 from version_utils import VersionFormat
+from camera_models import Radial_Dist_Camera, Dummy_Camera
 from video_capture import manager_classes
 from video_capture.base_backend import Base_Manager, Base_Source, Playback_Source
 
@@ -269,8 +268,8 @@ class Picoflexx_Source(Playback_Source, Base_Source):
 
     def get_init_dict(self):
         return {
-             "preview_depth": self._preview_depth,
-             "record_pointcloud": self.record_pointcloud,
+            "preview_depth": self._preview_depth,
+            "record_pointcloud": self.record_pointcloud,
             "auto_exposure": self._current_exposure_mode,
         }
 

--- a/backend.py
+++ b/backend.py
@@ -146,7 +146,7 @@ class DepthFrame(object):
     @property
     def bgr(self):
         if self._depth_img is None:
-            depth_values = self._data.z.reshape(self.height, self.width)
+            depth_values = self.true_depth.reshape(self.height, self.width)
             depth_values = (2 ** 16) * depth_values / depth_values.max()
             depth_values = depth_values.astype(np.uint16)
             self._depth_img = cython_methods.cumhist_color_map16(depth_values)
@@ -169,6 +169,11 @@ class DepthFrame(object):
     @property
     def noise(self):
         return self._data.noise.reshape(self.height, self.width)
+    
+    @property
+    def true_depth(self):
+        xyz = np.column_stack((self._data.x, self._data.y, self._data.z))
+        return np.linalg.norm(xyz, axis=1)
 
     @property
     def dense_pointcloud(self):

--- a/backend.py
+++ b/backend.py
@@ -30,8 +30,8 @@ from video_capture.base_backend import Base_Manager, Base_Source, Playback_Sourc
 logger = logging.getLogger(__name__)
 
 try:
-    import picoflexx.roypy as roypy
-    from picoflexx.roypy_platform_utils import PlatformHelper
+    from . import roypy as roypy
+    from .roypy_platform_utils import PlatformHelper
 except ImportError:
     import traceback
 

--- a/backend.py
+++ b/backend.py
@@ -394,6 +394,9 @@ class Picoflexx_Source(Playback_Source, Base_Source):
             self.camera = None
 
     def on_notify(self, notification):
+        if not self.menu:  # we've never been online
+            return
+
         if notification["subject"] == "picoflexx.set_exposure":
             self.set_exposure(notification["exposure"])
         elif notification["subject"] == "recording.started":


### PR DESCRIPTION
* Added `true_depth` property on `DepthFrame`s: The euclidean distance to each point from the origin
* Set the frame rate in `backend` so `world.mp4` plays back correctly externally
* Centralize logic for obtaining current camera settings/state
* Initialize menu with the active usecase instead of "Select usecase"
* Sanity checks when processing notifications
* Save exposure and usecase between sessions
* Fix error starting RRF recordings
* Save the offset used to adjust picoflexx timestamps in recording
   * So that timestamps in the RRF can be reconciled in the event of frame skips when starting a recording
* Render `IRFrame.img` instead of `.gray` so it may be modified in plugins 